### PR TITLE
Feature/update forwarder version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,8 +44,8 @@
     group: "{{ splunk_uf_system_group }}"
     mode: 0644
   when: splunk_uf_inputs_conf_template | default(false)
-  notify:
-    - restart splunkforwarder
+  # notify:
+  #   - restart splunkforwarder
   tags:
     - inputs
 
@@ -57,7 +57,7 @@
     group: "{{ splunk_uf_system_group }}"
     mode: 0644
   when: splunk_uf_outputs_conf_template | default(false)
-  notify:
-    - restart splunkforwarder
+  # notify:
+  #   - restart splunkforwarder
   tags:
     - outputs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,9 +28,6 @@
       groups: "{{ splunk_uf_system_group }}"
       append: yes
 
-  - name: install the splunk init script
-    command:  /opt/splunkforwarder/bin/splunk enable boot-start -user {{ splunk_uf_system_user|quote }}
-
   - name: store package installation result as boolean var
     set_fact:
       splunk_pkg_install: splunk_pkg_deb_install.changed or splunk_pkg_rpm_install.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,108 +3,64 @@
 
 - block:
 
-  # If you choose to run the splunk forwarder as root or an otherwise existing user,
-  # these calls won't override anything about the user, including their login shell.
-
-  # - name: add splunk user group to system
-  #   group:
-  #     name: "{{ splunk_uf_system_group }}"
-  #     state: present
-
-  # Allow for the creation of a home directory for this user, despite the nologin shell,
-  # so that Splunk can store it's session information in it's own .splunk directory.
-
-  # - name: add splunk user
-  #   user:
-  #     name: "{{ splunk_uf_system_user }}"
-  #     group: "{{ splunk_uf_system_group }}"
-  #     comment: "Splunk service user"
-  #     shell: /usr/sbin/nologin
-
-  # - name: install splunk binary from remote url
-  #   unarchive:
-  #     src: "{{ splunk_uf_install_url }}"
-  #     dest: /opt
-  #     remote_src: yes
-  #     creates: /opt/splunkforwarder/bin/splunk
-  #     owner: "{{ splunk_uf_system_user }}"
-  #     group: "{{ splunk_uf_system_group }}"
-
   - name: Validate required parameters and environment
     assert:
       that:
         - splunk_uf_install_url is defined
-        # - splunk_uf_deploy_server is defined
         - ansible_pkg_mgr is defined
         - ansible_pkg_mgr in ['yum', 'apt']
 
-  - name: download splunk package
-    get_url:
-      url: "{{ splunk_uf_install_url }}"
-      dest: /tmp
-    register: splunk_download
-    until: splunk_download is success
-    retries: 3
-    delay: 2
-
   - name: install the splunk deb package
     apt:
-      deb: "{{ splunk_download.dest }}"
+      deb: "{{ splunk_uf_install_url }}"
     when: ansible_pkg_mgr == 'apt'
     register: splunk_pkg_deb_install
 
   - name: install the splunk rpm package
     yum:
-      name: "{{ splunk_download.dest }}"
+      name: "{{ splunk_uf_install_url }}"
     when: ansible_pkg_mgr == 'yum'
     register: splunk_pkg_rpm_install
+
+  - name: add splunk user to the system group
+    user:
+      name: "{{ splunk_uf_system_user }}"
+      groups: "{{ splunk_uf_system_group }}"
+      append: yes
+
+  - name: install the splunk init script
+    command:  /opt/splunkforwarder/bin/splunk enable boot-start -user {{ splunk_uf_system_user|quote }}
 
   - name: store package installation result as boolean var
     set_fact:
       splunk_pkg_install: splunk_pkg_deb_install.changed or splunk_pkg_rpm_install.changed
 
-
-  # Ansible will use the assumed user shell by default, which in the case of a newly created
-  # non-root user (i.e. a "splunk" user) is a nologin shell.   To get around that, we use the
-  # `executable` argument to override the shell.
-
-  # - name: accept license and start splunk
-  #   shell: "/opt/splunkforwarder/bin/splunk set deploy-poll {{ splunk_uf_deploy_server }} --accept-license --answer-yes --auto-ports --no-prompt --gen-and-print-passwd"
-
-    # args:
-    #     executable: /bin/sh
-    # become_user: "{{ splunk_uf_system_user }}"
-
-  # - name: enable boot-start
-  #   shell: "/opt/splunkforwarder/bin/splunk enable boot-start"
-  #   when: splunk_uf_start_on_boot|bool
-
   become: yes
   tags:
     - install
 
-# - name: install inputs.conf via template
-#   template:
-#     src: "{{ splunk_uf_inputs_conf_template }}"
-#     dest: /opt/splunkforwarder/etc/system/local/inputs.conf
-#     owner: "{{ splunk_uf_system_user }}"
-#     group: "{{ splunk_uf_system_group }}"
-#     mode: 0644
-#   when: splunk_uf_inputs_conf_template | default(false)
-#   notify:
-#     - restart splunkforwarder
-#   tags:
-#     - inputs
+- name: install inputs.conf via template
+  template:
+    src: "{{ splunk_uf_inputs_conf_template }}"
+    dest: /opt/splunkforwarder/etc/system/local/inputs.conf
+    owner: "{{ splunk_uf_system_user }}"
+    group: "{{ splunk_uf_system_group }}"
+    mode: 0644
+  when: splunk_uf_inputs_conf_template | default(false)
+  notify:
+    - restart splunkforwarder
+  tags:
+    - inputs
 
-# - name: install outputs.conf via template
-#   template:
-#     src: "{{ splunk_uf_outputs_conf_template }}"
-#     dest: /opt/splunkforwarder/etc/system/local/outputs.conf
-#     owner: "{{ splunk_uf_system_user }}"
-#     group: "{{ splunk_uf_system_group }}"
-#     mode: 0644
-#   when: splunk_uf_outputs_conf_template | default(false)
-#   notify:
-#     - restart splunkforwarder
-#   tags:
-#     - outputs
+- name: install outputs.conf via template
+  template:
+    src: "{{ splunk_uf_outputs_conf_template }}"
+    dest: /opt/splunkforwarder/etc/system/local/outputs.conf
+    owner: "{{ splunk_uf_system_user }}"
+    group: "{{ splunk_uf_system_group }}"
+    mode: 0644
+  when: splunk_uf_outputs_conf_template | default(false)
+  notify:
+    - restart splunkforwarder
+  tags:
+    - outputs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,42 +2,82 @@
 # tasks file for splunk_forwarder
 
 - block:
+
   # If you choose to run the splunk forwarder as root or an otherwise existing user,
   # these calls won't override anything about the user, including their login shell.
-  - name: add splunk user group to system
-    group:
-      name: "{{ splunk_uf_system_group }}"
-      state: present
+
+  # - name: add splunk user group to system
+  #   group:
+  #     name: "{{ splunk_uf_system_group }}"
+  #     state: present
 
   # Allow for the creation of a home directory for this user, despite the nologin shell,
   # so that Splunk can store it's session information in it's own .splunk directory.
-  - name: add splunk user
-    user:
-      name: "{{ splunk_uf_system_user }}"
-      group: "{{ splunk_uf_system_group }}"
-      comment: "Splunk service user"
-      shell: /usr/sbin/nologin
 
-  - name: install splunk binary from remote url
-    unarchive:
-      src: "{{ splunk_uf_install_url }}"
-      dest: /opt
-      remote_src: yes
-      creates: /opt/splunkforwarder/bin/splunk
-      owner: "{{ splunk_uf_system_user }}"
-      group: "{{ splunk_uf_system_group }}"
+  # - name: add splunk user
+  #   user:
+  #     name: "{{ splunk_uf_system_user }}"
+  #     group: "{{ splunk_uf_system_group }}"
+  #     comment: "Splunk service user"
+  #     shell: /usr/sbin/nologin
+
+  # - name: install splunk binary from remote url
+  #   unarchive:
+  #     src: "{{ splunk_uf_install_url }}"
+  #     dest: /opt
+  #     remote_src: yes
+  #     creates: /opt/splunkforwarder/bin/splunk
+  #     owner: "{{ splunk_uf_system_user }}"
+  #     group: "{{ splunk_uf_system_group }}"
+
+  - name: Validate required parameters and environment
+    assert:
+      that:
+        - splunk_uf_install_url is defined
+        - splunk_uf_deploy_server is defined
+        - ansible_pkg_mgr is defined
+        - ansible_pkg_mgr in ['yum', 'apt']
+
+  - name: download splunk package
+    get_url:
+      url: "{{ splunk_uf_install_url }}"
+      dest: /tmp
+    register: splunk_download
+    until: splunk_download is success
+    retries: 3
+    delay: 2
+
+  - name: install the splunk deb package
+    apt:
+      deb: "{{ splunk_download.dest }}"
+    when: ansible_pkg_mgr == 'apt'
+    register: splunk_pkg_deb_install
+
+  - name: install the splunk rpm package
+    yum:
+      name: "{{ splunk_download.dest }}"
+    when: ansible_pkg_mgr == 'yum'
+    register: splunk_pkg_rpm_install
+
+  - name: store package installation result as boolean var
+    set_fact:
+      splunk_pkg_install: splunk_pkg_deb_install.changed or splunk_pkg_rpm_install.changed
+
 
   # Ansible will use the assumed user shell by default, which in the case of a newly created
   # non-root user (i.e. a "splunk" user) is a nologin shell.   To get around that, we use the
   # `executable` argument to override the shell.
   - name: accept license and start splunk
-    shell: /opt/splunkforwarder/bin/splunk start --answer-yes --no-prompt --accept-license
-    args:
-        executable: /bin/sh
-    become_user: "{{ splunk_uf_system_user }}"
+    # shell: /opt/splunkforwarder/bin/splunk start --answer-yes --no-prompt --accept-license
+    shell: "/opt/splunkforwarder/bin/splunk set deploy-poll {{ splunk_uf_deploy_server }} --accept-license --answer-yes --auto-ports --no-prompt --gen-and-print-passwd"
+
+    # args:
+    #     executable: /bin/sh
+    # become_user: "{{ splunk_uf_system_user }}"
 
   - name: enable boot-start
-    shell: "/opt/splunkforwarder/bin/splunk enable boot-start -user {{ splunk_uf_system_user}}"
+    # shell: "/opt/splunkforwarder/bin/splunk enable boot-start -user {{ splunk_uf_system_user}}"
+    shell: "/opt/splunkforwarder/bin/splunk enable boot-start"
     when: splunk_uf_start_on_boot|bool
 
   become: yes
@@ -57,15 +97,15 @@
   tags:
     - inputs
 
-- name: install outputs.conf via template
-  template:
-    src: "{{ splunk_uf_outputs_conf_template }}"
-    dest: /opt/splunkforwarder/etc/system/local/outputs.conf
-    owner: "{{ splunk_uf_system_user }}"
-    group: "{{ splunk_uf_system_group }}"
-    mode: 0644
-  when: splunk_uf_outputs_conf_template | default(false)
-  notify:
-    - restart splunkforwarder
-  tags:
-    - outputs
+# - name: install outputs.conf via template
+#   template:
+#     src: "{{ splunk_uf_outputs_conf_template }}"
+#     dest: /opt/splunkforwarder/etc/system/local/outputs.conf
+#     owner: "{{ splunk_uf_system_user }}"
+#     group: "{{ splunk_uf_system_group }}"
+#     mode: 0644
+#   when: splunk_uf_outputs_conf_template | default(false)
+#   notify:
+#     - restart splunkforwarder
+#   tags:
+#     - outputs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     assert:
       that:
         - splunk_uf_install_url is defined
-        - splunk_uf_deploy_server is defined
+        # - splunk_uf_deploy_server is defined
         - ansible_pkg_mgr is defined
         - ansible_pkg_mgr in ['yum', 'apt']
 
@@ -67,35 +67,34 @@
   # Ansible will use the assumed user shell by default, which in the case of a newly created
   # non-root user (i.e. a "splunk" user) is a nologin shell.   To get around that, we use the
   # `executable` argument to override the shell.
-  - name: accept license and start splunk
-    # shell: /opt/splunkforwarder/bin/splunk start --answer-yes --no-prompt --accept-license
-    shell: "/opt/splunkforwarder/bin/splunk set deploy-poll {{ splunk_uf_deploy_server }} --accept-license --answer-yes --auto-ports --no-prompt --gen-and-print-passwd"
+
+  # - name: accept license and start splunk
+  #   shell: "/opt/splunkforwarder/bin/splunk set deploy-poll {{ splunk_uf_deploy_server }} --accept-license --answer-yes --auto-ports --no-prompt --gen-and-print-passwd"
 
     # args:
     #     executable: /bin/sh
     # become_user: "{{ splunk_uf_system_user }}"
 
-  - name: enable boot-start
-    # shell: "/opt/splunkforwarder/bin/splunk enable boot-start -user {{ splunk_uf_system_user}}"
-    shell: "/opt/splunkforwarder/bin/splunk enable boot-start"
-    when: splunk_uf_start_on_boot|bool
+  # - name: enable boot-start
+  #   shell: "/opt/splunkforwarder/bin/splunk enable boot-start"
+  #   when: splunk_uf_start_on_boot|bool
 
   become: yes
   tags:
     - install
 
-- name: install inputs.conf via template
-  template:
-    src: "{{ splunk_uf_inputs_conf_template }}"
-    dest: /opt/splunkforwarder/etc/system/local/inputs.conf
-    owner: "{{ splunk_uf_system_user }}"
-    group: "{{ splunk_uf_system_group }}"
-    mode: 0644
-  when: splunk_uf_inputs_conf_template | default(false)
-  notify:
-    - restart splunkforwarder
-  tags:
-    - inputs
+# - name: install inputs.conf via template
+#   template:
+#     src: "{{ splunk_uf_inputs_conf_template }}"
+#     dest: /opt/splunkforwarder/etc/system/local/inputs.conf
+#     owner: "{{ splunk_uf_system_user }}"
+#     group: "{{ splunk_uf_system_group }}"
+#     mode: 0644
+#   when: splunk_uf_inputs_conf_template | default(false)
+#   notify:
+#     - restart splunkforwarder
+#   tags:
+#     - inputs
 
 # - name: install outputs.conf via template
 #   template:


### PR DESCRIPTION
This PR updates the Splunk forwarder version, and installs from an OS package rather than a zip file. 

Note that the configuration of the forwarder must be done in the instance userdata script. 

We may actually want to remove the inputs/outputs configuration from this role altogether.